### PR TITLE
add three versions of eslint

### DIFF
--- a/02_programming_fundamentals/03_algorithms_day_1/.eslintrc.js
+++ b/02_programming_fundamentals/03_algorithms_day_1/.eslintrc.js
@@ -1,0 +1,32 @@
+// If you want information about what a rule does
+// you can visite https://eslint.org/docs/rules/RULE_NAME
+
+module.exports = {
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": ["error", 2], // 2 spaces indentation
+        "linebreak-style": ["error","unix"], // line-breaks are unix
+        "quotes": ["error", "single"], // enforces single quotes
+        "semi": ["error", "always"], // semicolons must be there
+        "no-var": "error", // only let and const
+        "no-console": "allow", // allow console.log usage
+        "no-template-curly-in-string": "warn", // warns if you use the `${}` syntax inside a string
+        "array-callback-return": "error", // folding on an array must be done with a function that returns something
+        "eqeqeq": "error", // disallow `==` in favor of `===`
+        "no-global-assign": "error", // disalllow creating global variables without a declaration
+        "no-implied-eval": "error", // disallow calling setTimeout and setInterval with strings for the function argument
+        "no-param-reassign": "error", // prevent the redefining of a function
+        "no-return-assign": "error", // disallow assigning a variable inside a return
+        "no-self-compare": "error", // disallow `x === x`
+        "no-sequences": "error", // disallow this weird thing `var a = (3, 5); // a = 5`
+        "radix": "error", // force using a radix with `parseInt`
+        "global-require": "error", // force require to be called at the beggining of files
+        "handle-callback-err": "error", // force doing something with the error parameter of a callback
+        "no-mixed-requires": "error", // require should not be mixed with variables
+        "no-new-require": "error", // disallow using new with a require on the same line
+    }
+};

--- a/02_programming_fundamentals/04_algorithms_day_2/.eslintrc.js
+++ b/02_programming_fundamentals/04_algorithms_day_2/.eslintrc.js
@@ -1,0 +1,1 @@
+03_algorithms_day_1/.eslintrc.js

--- a/02_programming_fundamentals/05_callbacks/.eslintrc.js
+++ b/02_programming_fundamentals/05_callbacks/.eslintrc.js
@@ -1,0 +1,1 @@
+03_algorithms_day_1/.eslintrc.js

--- a/02_programming_fundamentals/06_your_first_program/.eslintrc.js
+++ b/02_programming_fundamentals/06_your_first_program/.eslintrc.js
@@ -1,0 +1,1 @@
+03_algorithms_day_1/.eslintrc.js

--- a/02_programming_fundamentals/07_file_management/.eslintrc.js
+++ b/02_programming_fundamentals/07_file_management/.eslintrc.js
@@ -1,0 +1,1 @@
+03_algorithms_day_1/.eslintrc.js

--- a/02_programming_fundamentals/08_this_day_1/.eslintrc.js
+++ b/02_programming_fundamentals/08_this_day_1/.eslintrc.js
@@ -1,0 +1,1 @@
+03_algorithms_day_1/.eslintrc.js

--- a/02_programming_fundamentals/09_this_day_2/.eslintrc.js
+++ b/02_programming_fundamentals/09_this_day_2/.eslintrc.js
@@ -1,0 +1,1 @@
+03_algorithms_day_1/.eslintrc.js

--- a/03_backend_developement/01_HTTP/.eslintrc.js
+++ b/03_backend_developement/01_HTTP/.eslintrc.js
@@ -1,0 +1,41 @@
+// If you want information about what a rule does
+// you can visite https://eslint.org/docs/rules/RULE_NAME
+
+module.exports = {
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": ["error", 2], // 2 spaces indentation
+        "linebreak-style": ["error","unix"], // line-breaks are unix
+        "quotes": ["error", "single"], // enforces single quotes
+        "semi": ["error", "always"], // semicolons must be there
+        "no-var": "error", // only let and const
+        "no-console": "allow", // allow console.log usage
+        "no-template-curly-in-string": "warn", // warns if you use the `${}` syntax inside a string
+        "array-callback-return": "error", // folding on an array must be done with a function that returns something
+        "eqeqeq": "error", // disallow `==` in favor of `===`
+        "no-global-assign": "error", // disalllow creating global variables without a declaration
+        "no-implied-eval": "error", // disallow calling setTimeout and setInterval with strings for the function argument
+        "no-param-reassign": "error", // prevent the redefining of a function
+        "no-return-assign": "error", // disallow assigning a variable inside a return
+        "no-self-compare": "error", // disallow `x === x`
+        "no-sequences": "error", // disallow this weird thing `var a = (3, 5); // a = 5`
+        "radix": "error", // force using a radix with `parseInt`
+        "global-require": "error", // force require to be called at the beggining of files
+        "handle-callback-err": "error", // force doing something with the error parameter of a callback
+        "no-mixed-requires": "error", // require should not be mixed with variables
+        "no-new-require": "error", // disallow using new with a require on the same line
+
+        // INTERMEDIATE
+        "no-multi-spaces": "error", // forbit useless spaces
+        "no-new": "error", // can't use `new` without asigning the result to a variable
+        "no-unmodified-loop-condition": "error", // condition of a loop must be changed inside of the loop and not by mutation
+        "no-useless-concat": "error", // disallow `"a" + "b"` in favor of `"ab"`
+        "no-path-concat": "error", // force using path for joining directories (avoid messing with OS)
+        "no-duplicate-imports": "error", // disallow importing twice from the same lib
+        "prefer-const": "error", // prevents using let for variables that are never reassigned
+    }
+};

--- a/03_backend_developement/03_testing_our_code/.eslintrc.js
+++ b/03_backend_developement/03_testing_our_code/.eslintrc.js
@@ -1,0 +1,1 @@
+01_HTTP/.eslintrc.js

--- a/03_backend_developement/04_first_API_day_1/.eslintrc.js
+++ b/03_backend_developement/04_first_API_day_1/.eslintrc.js
@@ -1,0 +1,1 @@
+01_HTTP/.eslintrc.js

--- a/03_backend_developement/05_first_API_day_2/.eslintrc.js
+++ b/03_backend_developement/05_first_API_day_2/.eslintrc.js
@@ -1,0 +1,1 @@
+01_HTTP/.eslintrc.js

--- a/03_backend_developement/06_data_modeling_&_databases/.eslintrc.js
+++ b/03_backend_developement/06_data_modeling_&_databases/.eslintrc.js
@@ -1,0 +1,1 @@
+01_HTTP/.eslintrc.js

--- a/03_backend_developement/07_building_a_basic_product_catalog/.eslintrc.js
+++ b/03_backend_developement/07_building_a_basic_product_catalog/.eslintrc.js
@@ -1,0 +1,1 @@
+01_HTTP/.eslintrc.js

--- a/03_backend_developement/08_database_queries_(SQL)/.eslintrc.js
+++ b/03_backend_developement/08_database_queries_(SQL)/.eslintrc.js
@@ -1,0 +1,1 @@
+01_HTTP/.eslintrc.js

--- a/03_backend_developement/09_commerce_API_project_day_1/.eslintrc.js
+++ b/03_backend_developement/09_commerce_API_project_day_1/.eslintrc.js
@@ -1,0 +1,1 @@
+01_HTTP/.eslintrc.js

--- a/03_backend_developement/10_commerce_API_project_day_2/.eslintrc.js
+++ b/03_backend_developement/10_commerce_API_project_day_2/.eslintrc.js
@@ -1,0 +1,1 @@
+01_HTTP/.eslintrc.js

--- a/04_frontend_development/01_HTML_&_CSS/.eslintrc.js
+++ b/04_frontend_development/01_HTML_&_CSS/.eslintrc.js
@@ -1,0 +1,1 @@
+../03_backend_developement/01_HTTP/.eslintrc.js

--- a/04_frontend_development/02_responsiveness_with_bootstrap/.eslintrc.js
+++ b/04_frontend_development/02_responsiveness_with_bootstrap/.eslintrc.js
@@ -1,0 +1,1 @@
+../03_backend_developement/01_HTTP/.eslintrc.js

--- a/04_frontend_development/03_building_a_web_application/.eslintrc.js
+++ b/04_frontend_development/03_building_a_web_application/.eslintrc.js
@@ -1,0 +1,1 @@
+../03_backend_developement/01_HTTP/.eslintrc.js

--- a/04_frontend_development/04_commerce_store_front/.eslintrc.js
+++ b/04_frontend_development/04_commerce_store_front/.eslintrc.js
@@ -1,0 +1,1 @@
+../03_backend_developement/01_HTTP/.eslintrc.js

--- a/04_frontend_development/05_hosting_&_deployment_with_Heroku/.eslintrc.js
+++ b/04_frontend_development/05_hosting_&_deployment_with_Heroku/.eslintrc.js
@@ -1,0 +1,1 @@
+../03_backend_developement/01_HTTP/.eslintrc.js

--- a/05_tricount_project/01_user_authentication/.eslintrc.js
+++ b/05_tricount_project/01_user_authentication/.eslintrc.js
@@ -1,0 +1,48 @@
+// If you want information about what a rule does
+// you can visite https://eslint.org/docs/rules/RULE_NAME
+
+module.exports = {
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": ["error", 2], // 2 spaces indentation
+        "linebreak-style": ["error","unix"], // line-breaks are unix
+        "quotes": ["error", "single"], // enforces single quotes
+        "semi": ["error", "always"], // semicolons must be there
+        "no-var": "error", // only let and const
+        "no-console": "allow", // allow console.log usage
+        "no-template-curly-in-string": "warn", // warns if you use the `${}` syntax inside a string
+        "array-callback-return": "error", // folding on an array must be done with a function that returns something
+        "eqeqeq": "error", // disallow `==` in favor of `===`
+        "no-global-assign": "error", // disalllow creating global variables without a declaration
+        "no-implied-eval": "error", // disallow calling setTimeout and setInterval with strings for the function argument
+        "no-param-reassign": "error", // prevent the redefining of a function
+        "no-return-assign": "error", // disallow assigning a variable inside a return
+        "no-self-compare": "error", // disallow `x === x`
+        "no-sequences": "error", // disallow this weird thing `var a = (3, 5); // a = 5`
+        "radix": "error", // force using a radix with `parseInt`
+        "global-require": "error", // force require to be called at the beggining of files
+        "handle-callback-err": "error", // force doing something with the error parameter of a callback
+        "no-mixed-requires": "error", // require should not be mixed with variables
+        "no-new-require": "error", // disallow using new with a require on the same line
+
+        // INTERMEDIATE
+        "no-multi-spaces": "error", // forbit useless spaces
+        "no-new": "error", // can't use `new` without asigning the result to a variable
+        "no-unmodified-loop-condition": "error", // condition of a loop must be changed inside of the loop and not by mutation
+        "no-useless-concat": "error", // disallow `"a" + "b"` in favor of `"ab"`
+        "no-path-concat": "error", // force using path for joining directories (avoid messing with OS)
+        "no-duplicate-imports": "error", // disallow importing twice from the same lib
+        "prefer-const": "error", // prevents using let for variables that are never reassigned
+
+        // EXPERT
+        "no-implicit-coercion": "error", // disallow things like `!!foo` in favor of `Boolean(foo)`
+        "no-loop-func": "error", // disallow functions inside of loops
+        "no-magic-numbers": ["error", { "ignoreArrayIndexes": true }], // force to name constants used several times (except for array keys)
+        "prefer-template": "warning", // suggest to use template string instead of concatenation
+        "sort-imports": "warning", // suggest alphabetical ordering for imports
+    }
+};

--- a/05_tricount_project/02_data_modeling/.eslintrc.js
+++ b/05_tricount_project/02_data_modeling/.eslintrc.js
@@ -1,0 +1,1 @@
+01_user_authentication/.eslintrc.js

--- a/05_tricount_project/03_facebook_connect_&_friend_group/.eslintrc.js
+++ b/05_tricount_project/03_facebook_connect_&_friend_group/.eslintrc.js
@@ -1,0 +1,1 @@
+01_user_authentication/.eslintrc.js

--- a/05_tricount_project/04_expenses_form/.eslintrc.js
+++ b/05_tricount_project/04_expenses_form/.eslintrc.js
@@ -1,0 +1,1 @@
+01_user_authentication/.eslintrc.js

--- a/05_tricount_project/05_payback_summary/.eslintrc.js
+++ b/05_tricount_project/05_payback_summary/.eslintrc.js
@@ -1,0 +1,1 @@
+01_user_authentication/.eslintrc.js

--- a/06_react_redux/01_classes/.eslintrc.js
+++ b/06_react_redux/01_classes/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/02_dynamism_in_web/.eslintrc.js
+++ b/06_react_redux/02_dynamism_in_web/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/03_introducing_react/.eslintrc.js
+++ b/06_react_redux/03_introducing_react/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/04_props/.eslintrc.js
+++ b/06_react_redux/04_props/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/05_state/.eslintrc.js
+++ b/06_react_redux/05_state/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/06_lifecycle_method/.eslintrc.js
+++ b/06_react_redux/06_lifecycle_method/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/07_react_router_day_1/.eslintrc.js
+++ b/06_react_redux/07_react_router_day_1/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/08_react_router_day_2/.eslintrc.js
+++ b/06_react_redux/08_react_router_day_2/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/09_talking_to_api_day_1/.eslintrc.js
+++ b/06_react_redux/09_talking_to_api_day_1/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/06_react_redux/10_talking_to_api_day_2/.eslintrc.js
+++ b/06_react_redux/10_talking_to_api_day_2/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/07_react_native/01_setup/.eslintrc.js
+++ b/07_react_native/01_setup/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/07_react_native/02_first_mobile_app/.eslintrc.js
+++ b/07_react_native/02_first_mobile_app/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/07_react_native/03_geolocation/.eslintrc.js
+++ b/07_react_native/03_geolocation/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/07_react_native/04_get_photos/.eslintrc.js
+++ b/07_react_native/04_get_photos/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/07_react_native/05_edit_catalogue/.eslintrc.js
+++ b/07_react_native/05_edit_catalogue/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/08_first_project/01_redux_day_1/.eslintrc.js
+++ b/08_first_project/01_redux_day_1/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/08_first_project/02_redux_day_2/.eslintrc.js
+++ b/08_first_project/02_redux_day_2/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/08_first_project/03_redux_good_practices/.eslintrc.js
+++ b/08_first_project/03_redux_good_practices/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/08_first_project/04_redux_thunk_day_1/.eslintrc.js
+++ b/08_first_project/04_redux_thunk_day_1/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js

--- a/08_first_project/05_redux_thunk_day_2/.eslintrc.js
+++ b/08_first_project/05_redux_thunk_day_2/.eslintrc.js
@@ -1,0 +1,1 @@
+../05_tricount_project/01_user_authentication/.eslintrc.js


### PR DESCRIPTION
It's just a proposal for Eslint but I cut it in three pieces (and everything else is symbolic links).

The first one start with `02_programming_fundamentals/03_algorithms_day_1`.

The second one with `03_backend_development/01_HTTP`.

And the last one with `05_tricount_project/01_user_authentication`

With gradual rules where I have put a comment for each ones of them if you want to chime in.
For the moment, there is nothing about stylistics rules, only language gotchas.