### PR TITLE
rename a duplicate package name to help using jest on all of them

### DIFF
--- a/02_programming_fundamentals/04_algorithms_day_2/06_fizz_buzz_with_map/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/06_fizz_buzz_with_map/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fizz_buzz",
+  "name": "fizz_buzz_with_map",
   "version": "1.0.0",
   "description": "Fizz buzz is a group word game for children to teach them about division. Players take turns to count incrementally, replacing any number divisible by three with the word `fizz`, and any number divisible by five with the word `buzz`.",
   "main": "fizz_buzz_map.js",


### PR DESCRIPTION
when running commands for launching all tests on the project, jest raises a warning:

<details>
jest-haste-map: @providesModule naming collision:
  Duplicate module name: fizz_buzz
  Paths: /Users/fenn/Workspace/fewlines/camp2_exercises_solutions/02_programming_fundamentals/04_algorithms_day_2/06_fizz_buzz_with_map/package.json collides with /Users/fenn/Workspace/fewlines/camp2_exercises_solutions/02_programming_fundamentals/04_algorithms_day_2/03_fizz_buzz/package.json

This warning is caused by a @providesModule declaration with the same name across two different files.
</details>

It does not cost us anything to prevent this so here is a simple rename.