### PR TITLE
correct to take the result deletion into account

### DIFF
--- a/03_backend_developement/01_HTTP/02_curl_get/.__tests__/01_postman_api_call.test.js
+++ b/03_backend_developement/01_HTTP/02_curl_get/.__tests__/01_postman_api_call.test.js
@@ -33,9 +33,9 @@ test("Check that the result file exists", done => {
 
 test("Check that the call has been done", done => {
   expect.assertions(1);
-  const result = fs.readFileSync(resultFile(), "utf8");
 
   exec(`bash ${commandFile()}`).then(() => {
+    const result = fs.readFileSync(resultFile(), "utf8");
     curl("https://postman-echo.com/get", curlHeader).then(curlResult => {
       expect(curlResult).toEqual(result);
       done();

--- a/03_backend_developement/01_HTTP/02_curl_get/.__tests__/02_postman_api_call.test.js
+++ b/03_backend_developement/01_HTTP/02_curl_get/.__tests__/02_postman_api_call.test.js
@@ -33,9 +33,9 @@ test("Check that the result file exists", done => {
 
 test("Check that the call has been done", done => {
   expect.assertions(1);
-  const result = fs.readFileSync(resultFile(), "utf8");
 
   exec(`bash ${commandFile()}`).then(() => {
+    const result = fs.readFileSync(resultFile(), "utf8");
     curl("https://postman-echo.com/get?foo=bar", curlHeader).then(curlResult => {
       const args = JSON.parse(curlResult).args;
       expect(JSON.stringify(args, null, 2) + "\n").toEqual(result);

--- a/03_backend_developement/01_HTTP/02_curl_get/.__tests__/03_postman_api_call.test.js
+++ b/03_backend_developement/01_HTTP/02_curl_get/.__tests__/03_postman_api_call.test.js
@@ -43,9 +43,9 @@ test("Check that the result file is not empty (does the curl call work?)", done 
 
 test("Check that the call has been done", done => {
   expect.assertions(1);
-  const result = fs.readFileSync(resultFile(), "utf8");
 
   exec(`bash ${commandFile()}`).then(() => {
+    const result = fs.readFileSync(resultFile(), "utf8");
     curl("https://postman-echo.com/get?foo=bar&program=camp2", curlHeader).then(curlResult => {
       const args = JSON.parse(curlResult).args;
       expect(JSON.stringify(args, null, 2) + "\n").toEqual(result);

--- a/03_backend_developement/01_HTTP/02_curl_get/.__tests__/04_postman_api_call.test.js
+++ b/03_backend_developement/01_HTTP/02_curl_get/.__tests__/04_postman_api_call.test.js
@@ -43,9 +43,9 @@ test("Check that the result file is not empty (does the curl call work?)", done 
 
 test("Check that the call has been done", done => {
   expect.assertions(1);
-  const result = fs.readFileSync(resultFile(), "utf8");
 
   exec(`bash ${commandFile()}`).then(() => {
+    const result = fs.readFileSync(resultFile(), "utf8");
     curl(
       "https://postman-echo.com/get?foo=bar&program=camp2&people[]=Frieda&people[]=Francis",
       curlHeader

--- a/03_backend_developement/01_HTTP/02_curl_get/.__tests__/05_postman_api_call.test.js
+++ b/03_backend_developement/01_HTTP/02_curl_get/.__tests__/05_postman_api_call.test.js
@@ -43,20 +43,20 @@ test("Check that the result file is not empty (does the curl call work?)", done 
 
 test("Check that the call has been done", done => {
   expect.assertions(1);
-  const result = fs.readFileSync(resultFile(), "utf8");
+
+  const date = new Date();
+  const dateYear =
+    date.getFullYear() +
+    "-" +
+    (date.getMonth() + 1).toString().padStart(2, "0") +
+    "-" +
+    date
+      .getDate()
+      .toString()
+      .padStart(2, "0");
 
   exec(`bash ${commandFile()}`).then(() => {
-    const date = new Date();
-    const dateYear =
-      date.getFullYear() +
-      "-" +
-      (date.getMonth() + 1).toString().padStart(2, "0") +
-      "-" +
-      date
-        .getDate()
-        .toString()
-        .padStart(2, "0");
-
+    const result = fs.readFileSync(resultFile(), "utf8");
     curl(
       `https://postman-echo.com/time/valid?timestamp=${dateYear}`,
       curlHeader

--- a/03_backend_developement/01_HTTP/03_curl_post/.__tests__/01_postman_api_post.test.js
+++ b/03_backend_developement/01_HTTP/03_curl_post/.__tests__/01_postman_api_post.test.js
@@ -33,9 +33,9 @@ test("Check that the result file exists", done => {
 
 test("Check that the call has been done", done => {
   expect.assertions(1);
-  const result = fs.readFileSync(resultFile(), "utf8");
 
   exec(`bash ${commandFile()}`).then(() => {
+    const result = fs.readFileSync(resultFile(), "utf8");
     curl("https://postman-echo.com/post", {"Hello from postman":""},curlHeader).then(curlResult => {
       const formData = JSON.parse(curlResult).form;
       expect(JSON.stringify(formData, null, 2) + "\n").toEqual(result);

--- a/03_backend_developement/01_HTTP/03_curl_post/.__tests__/02_postman_api_post.test.js
+++ b/03_backend_developement/01_HTTP/03_curl_post/.__tests__/02_postman_api_post.test.js
@@ -33,9 +33,9 @@ test("Check that the result file exists", done => {
 
 test("Check that the call has been done", done => {
   expect.assertions(1);
-  const result = fs.readFileSync(resultFile(), "utf8");
 
   exec(`bash ${commandFile()}`).then(() => {
+    const result = fs.readFileSync(resultFile(), "utf8");
     curl("https://postman-echo.com/post", {"foo":"bar"},curlHeader).then(curlResult => {
       const formData = JSON.parse(curlResult).form;
       expect(JSON.stringify(formData, null, 2) + "\n").toEqual(result);

--- a/03_backend_developement/01_HTTP/03_curl_post/.__tests__/03_postman_api_post.test.js
+++ b/03_backend_developement/01_HTTP/03_curl_post/.__tests__/03_postman_api_post.test.js
@@ -33,9 +33,9 @@ test("Check that the result file exists", done => {
 
 test("Check that the call has been done", done => {
   expect.assertions(1);
-  const result = fs.readFileSync(resultFile(), "utf8");
 
   exec(`bash ${commandFile()}`).then(() => {
+    const result = fs.readFileSync(resultFile(), "utf8");
     curl("https://postman-echo.com/post", {"foo":"bar"},curlHeader).then(curlResult => {
       const formData = JSON.parse(curlResult).form;
       expect(JSON.stringify(formData, null, 2) + "\n").toEqual(result);


### PR DESCRIPTION
The `.result` file was ignored at first and we added in a rush a `afterEach` that deletes the file.
There were tests that checked for the result file before executing the command though.