### PR TITLE
Ignore eslint in tests

### DIFF
--- a/02_programming_fundamentals/03_algorithms_day_1/01_play_with_variables/package.json
+++ b/02_programming_fundamentals/03_algorithms_day_1/01_play_with_variables/package.json
@@ -12,5 +12,8 @@
   },
   "jest": {
     "noStackTrace": true
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/03_algorithms_day_1/02_play_with_arrays/package.json
+++ b/02_programming_fundamentals/03_algorithms_day_1/02_play_with_arrays/package.json
@@ -12,5 +12,8 @@
   },
   "jest": {
     "noStackTrace": true
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/03_algorithms_day_1/03_play_with_conditional_statement/package.json
+++ b/02_programming_fundamentals/03_algorithms_day_1/03_play_with_conditional_statement/package.json
@@ -12,5 +12,8 @@
   },
   "jest": {
     "noStackTrace": true
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/03_algorithms_day_1/04_play_with_for_loop/package.json
+++ b/02_programming_fundamentals/03_algorithms_day_1/04_play_with_for_loop/package.json
@@ -11,5 +11,8 @@
   },
   "jest": {
     "noStackTrace": true
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/03_algorithms_day_1/05_play_with_for_loop_bonus/package.json
+++ b/02_programming_fundamentals/03_algorithms_day_1/05_play_with_for_loop_bonus/package.json
@@ -12,5 +12,8 @@
   },
   "jest": {
     "noStackTrace": true
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/03_algorithms_day_1/06_pattern/package.json
+++ b/02_programming_fundamentals/03_algorithms_day_1/06_pattern/package.json
@@ -9,5 +9,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/04_algorithms_day_2/01_range_function/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/01_range_function/package.json
@@ -8,5 +8,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/04_algorithms_day_2/02_car_rental/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/02_car_rental/package.json
@@ -8,5 +8,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/04_algorithms_day_2/03_fizz_buzz/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/03_fizz_buzz/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/04_algorithms_day_2/04_filter/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/04_filter/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/04_algorithms_day_2/05_map_double/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/05_map_double/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/04_algorithms_day_2/06_fizz_buzz_with_map/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/06_fizz_buzz_with_map/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/04_algorithms_day_2/07_join_array/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/07_join_array/package.json
@@ -8,5 +8,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/04_algorithms_day_2/08_recursion_bonus/package.json
+++ b/02_programming_fundamentals/04_algorithms_day_2/08_recursion_bonus/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/05_callbacks/01_using_callbacks/package.json
+++ b/02_programming_fundamentals/05_callbacks/01_using_callbacks/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/05_callbacks/02_create_callbacks/package.json
+++ b/02_programming_fundamentals/05_callbacks/02_create_callbacks/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/05_callbacks/03_square_digits/package.json
+++ b/02_programming_fundamentals/05_callbacks/03_square_digits/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/05_callbacks/04_complete_the_pattern/package.json
+++ b/02_programming_fundamentals/05_callbacks/04_complete_the_pattern/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/05_callbacks/05_morse_code/package.json
+++ b/02_programming_fundamentals/05_callbacks/05_morse_code/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/05_callbacks/06_sort_an_array/package.json
+++ b/02_programming_fundamentals/05_callbacks/06_sort_an_array/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/05_callbacks/07_colorful_numbers/package.json
+++ b/02_programming_fundamentals/05_callbacks/07_colorful_numbers/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/06_your_first_program/01_number_game/package.json
+++ b/02_programming_fundamentals/06_your_first_program/01_number_game/package.json
@@ -13,5 +13,8 @@
   },
   "jest": {
     "noStackTrace": true
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/06_your_first_program/02_number_game_with_stats/package.json
+++ b/02_programming_fundamentals/06_your_first_program/02_number_game_with_stats/package.json
@@ -13,5 +13,8 @@
   },
   "jest": {
     "noStackTrace": true
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/06_your_first_program/03_memory/package.json
+++ b/02_programming_fundamentals/06_your_first_program/03_memory/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "cli-clear": "^1.0.4"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/07_file_management/01_basic_fs/package.json
+++ b/02_programming_fundamentals/07_file_management/01_basic_fs/package.json
@@ -9,5 +9,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/07_file_management/02_finder_1/package.json
+++ b/02_programming_fundamentals/07_file_management/02_finder_1/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/07_file_management/03_finder_2/package.json
+++ b/02_programming_fundamentals/07_file_management/03_finder_2/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/07_file_management/04_number_game/package.json
+++ b/02_programming_fundamentals/07_file_management/04_number_game/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/08_this_day_1/01_using_this/package.json
+++ b/02_programming_fundamentals/08_this_day_1/01_using_this/package.json
@@ -9,5 +9,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/08_this_day_1/02_chaining/package.json
+++ b/02_programming_fundamentals/08_this_day_1/02_chaining/package.json
@@ -9,5 +9,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/08_this_day_1/03_implementing/package.json
+++ b/02_programming_fundamentals/08_this_day_1/03_implementing/package.json
@@ -9,5 +9,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }

--- a/02_programming_fundamentals/08_this_day_1/04_bonus/package.json
+++ b/02_programming_fundamentals/08_this_day_1/04_bonus/package.json
@@ -9,5 +9,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^23.6.0"
-  }
+  },
+  "eslintIgnore": [
+    "__tests__"
+  ]
 }


### PR DESCRIPTION
The previous change that forced us to make `__tests__` directories instead of `.__tests__` also added those tests in the `eslint .` part of the tests which is not good as we would need to add plugins to eslint to ignore jest globals.

This PR then adds an `ignoreEslint` entry to `package.json`s to avoid those problems.